### PR TITLE
↗️ Made the container usable for other shows

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,5 @@ volumes:
     driver_opts:
       type: "nfs"
       o: "addr=192.168.5.10,nolock,soft,ro"
-      device: ":/volume1/plex-media/shows/"
+      device: ":/volume1/plex-media/shows/(2013) Marvel's Agents of S.H.I.E.L.D/"
 

--- a/src/html/aos.php
+++ b/src/html/aos.php
@@ -21,7 +21,7 @@
       	$start = ((60*$startm)+$starts);
       	$end = (((60*$endm)+$ends)-$start);
 
-      	$pfad = "/source/Marvel's Agents of S.H.I.E.L.D/";
+      	$pfad = "/source/";
 
       	$list="cd \"$pfad\" && ls -d */* | grep $episode";
       	$video=exec("$list");


### PR DESCRIPTION
Just mount the fitting folder as a volume to /input